### PR TITLE
Closes #1

### DIFF
--- a/lib/sha3-pure-ruby.rb
+++ b/lib/sha3-pure-ruby.rb
@@ -41,7 +41,7 @@ module Digest
       width = 200 - @size * 2
       
       buffer = @buffer
-      buffer << "\x01" << "\0" * (width - buffer.size % width)
+      buffer << "\x06" << "\0" * (width - buffer.size % width)
       buffer[-1] = (buffer[-1].ord | 0x80).chr
       
       0.step buffer.size - 1, width do |j|

--- a/test/test_sha3-pure-ruby.rb
+++ b/test/test_sha3-pure-ruby.rb
@@ -2,51 +2,56 @@ require File.expand_path '../../lib/sha3-pure-ruby', __FILE__
 require 'minitest/autorun'
 require 'minitest/pride'
 
+# http://emn178.github.io/online-tools/sha3_224.html
+# http://emn178.github.io/online-tools/sha3_256.html
+# http://emn178.github.io/online-tools/sha3_512.html
+# http://emn178.github.io/online-tools/sha3_384.html
+
 describe Digest::SHA3 do
   describe 'default 512-bit' do
     it 'should work when empty' do
-      empty_string_sha3 = '0eab42de4c3ceb9235fc91acffe746b29c29a8c366b7c60e4e67c466f36a4304c00fa9caf9d87976ba469bcbe06713b435f091ef2769fb160cdab33d3670680e'
+      empty_string_sha3 = 'a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26'
       assert_equal Digest::SHA3.new.hexdigest(''), empty_string_sha3
     end
     
     it 'should work with content' do
-      cat_sha3 = "b2faf80c85bd36029dc3f804cbf439888fd1ca195ab0e3decb872f8aa9ef767e4866186ebb8b5ecfa1237147a94775f8302648be0fd0ae3a6ebbdf931f423360"
+      cat_sha3 = "fe37dd66fa849ca98684160d542538b22c1edb576271d76b319ded4965d90143a0806fe1edf29b82b8740ec177880769629bdd1a0fb7cb97d7640e60c44833d3"
       assert_equal Digest::SHA3.new.hexdigest('cat'), cat_sha3
     end
   end
   
   describe '384-bit' do
     it 'should work when empty' do
-      empty_string_sha3 = '2c23146a63a29acf99e73b88f8c24eaa7dc60aa771780ccc006afbfa8fe2479b2dd2b21362337441ac12b515911957ff'
+      empty_string_sha3 = '0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004'
       assert_equal Digest::SHA3.new(384).hexdigest(''), empty_string_sha3
     end
     
     it 'should work with content' do
-      cat_sha3 = 'fbcae9b945da6967b622e93e5712dcd0b4df2f522a89b0a20b485684c02efcf9efafb699499b2328172cbf654b7721c5'
+      cat_sha3 = '9bb4adf3004b3ed61f76195321621eac835b6502db486a53b64fdb69c50ee1a8dbb05c950577db70be2bafed59f8891d'
       assert_equal Digest::SHA3.new(384).hexdigest('cat'), cat_sha3
     end
   end
   
   describe '256-bit' do
     it 'should work when empty' do
-      empty_string_sha3 = 'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
+      empty_string_sha3 = 'a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a'
       assert_equal Digest::SHA3.new(256).hexdigest(''), empty_string_sha3
     end
     
     it 'should work with content' do
-      cat_sha3 = '52763589e772702fa7977a28b3cfb6ca534f0208a2b2d55f7558af664eac478a'
+      cat_sha3 = 'd616607d3e4ba96a74f323cffc5f20a3c78e7cab8ecbdbb03b13fa8ffc9bf644'
       assert_equal Digest::SHA3.new(256).hexdigest('cat'), cat_sha3
     end
   end
   
   describe '224-bit' do
     it 'should work when empty' do
-      empty_string_sha3 = 'f71837502ba8e10837bdd8d365adb85591895602fc552b48b7390abd'
+      empty_string_sha3 = '6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7'
       assert_equal Digest::SHA3.new(224).hexdigest(''), empty_string_sha3
     end
     
     it 'should work with content' do
-      cat_sha3 = "c3e4d225cefd1d01166d801f856907492b3bf8909a8a3a5bc922580f"
+      cat_sha3 = "447c857980c93d613b8bd6897c05bfd0621245139f021aaa6b57830a"
       assert_equal Digest::SHA3.new(224).hexdigest('cat'), cat_sha3
     end
   end


### PR DESCRIPTION
Hashes compliant to [FIPS 202](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) (pdf) and tests fixes

```
Run options: --seed 53555

# Running:

........

Fabulous run in 0.017158s, 466.2500 runs/s, 466.2500 assertions/s.

8 runs, 8 assertions, 0 failures, 0 errors, 0 skips
```
